### PR TITLE
Correction on bug for on_memory read: fid.tell() method was not wrapped

### DIFF
--- a/ncempy/io/dm.py
+++ b/ncempy/io/dm.py
@@ -107,6 +107,12 @@ class fileDM:
                 print('Closing tags output file')
             self.fidOut.close()
             
+    def tell(self):
+        if self._on_memory:
+            return self._buffer_offset
+        else:
+            return self.fid.tell()
+        
     def fromfile(self, *args, **kwargs):
         """ Reads data from a file or momery map. 
         Calls np.fromfile and np.frombuffer depending on the on_memory mode of
@@ -520,7 +526,7 @@ class fileDM:
         if self.curTagName == 'Data':
             #This is a binary array. Save its location to read later if needed
             self._storeTag(self.curTagName + '.arraySize', bufSize)
-            self._storeTag(self.curTagName + '.arrayOffset', self.fid.tell())
+            self._storeTag(self.curTagName + '.arrayOffset', self.tell())
             self._storeTag(self.curTagName + '.arrayType', encodedType)
             self.seek(self.fid, bufSize.astype('<u8'),1) #advance the pointer by bufsize from current position
             arrOut = 'Data unread. Encoded type = {}'.format(encodedType)
@@ -542,7 +548,7 @@ class fileDM:
                 self.origin.append(self.origin_temp)
         else:
             self._storeTag(self.curTagName + '.arraySize', bufSize)
-            self._storeTag(self.curTagName + '.arrayOffset', self.fid.tell())
+            self._storeTag(self.curTagName + '.arrayOffset', self.tell())
             self._storeTag(self.curTagName + '.arrayType', encodedType)
             self.seek(self.fid, bufSize.astype('<u8'),1) #advance the pointer by bufsize from current position
             arrOut = 'Array unread. Encoded type = {}'.format(encodedType)

--- a/ncempy/test/test_io_dm.py
+++ b/ncempy/test/test_io_dm.py
@@ -115,4 +115,27 @@ class test_dm3(unittest.TestCase):
             
             self.assertGreater(delta0, delta1)
         
+    def test_extract_on_memory(self):
+        from matplotlib.image import imsave
+        from matplotlib import cm
+        f = ncempy.io.dm.fileDM(
+            self._get_image_route("Capture5_Hour_00_Minute_02_Second_40_Frame_0323.dm4"),
+            on_memory=False)
+        
+        f.parseHeader()
+        ds = f.getDataset(0)
+        img3D_no_on_mem = ds['data']
+        
+        del f
+        
+        f = ncempy.io.dm.fileDM(
+            self._get_image_route("Capture5_Hour_00_Minute_02_Second_40_Frame_0323.dm4"),
+            on_memory=True)
+        
+        f.parseHeader()
+        ds = f.getDataset(0)
+        img3D_on_mem = ds['data']
+      
+        del f
+        self.assertTrue((img3D_no_on_mem==img3D_on_mem).all())
         


### PR DESCRIPTION
Symptom: some dm3/dm4 preview images looked shifted when extracted with on_memory mode.

Cause: The code identifying subarrays would give an offset 0 to all in the detected subarrays. This was because fid.tell() was not wrapped and returned always 0 in on_memory mode.

Actions:
- fid.tell() wapped with self.tell()
- Added unittest that compare the ds["data"] obtained from a file that triggered the fail.

